### PR TITLE
Specified Java file encoding in .editorconfig

### DIFF
--- a/src/main/resources/archetype-resources/.editorconfig
+++ b/src/main/resources/archetype-resources/.editorconfig
@@ -13,3 +13,7 @@ trim_trailing_whitespace = true
 # Files with a smaller indent
 [*.{java,xml}]
 indent_size = 2
+
+# Java file encoding
+[*.java]
+charset = utf-8


### PR DESCRIPTION
To match the Maven configuration.