### PR TITLE
Ignore IntelliJ encoding file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,6 @@ buildNumber.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### IntelliJ with EditorConfig ###
+.idea/encodings.xml

--- a/src/main/resources/archetype-resources/.gitignore
+++ b/src/main/resources/archetype-resources/.gitignore
@@ -270,3 +270,6 @@ buildNumber.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### IntelliJ with EditorConfig ###
+.idea/encodings.xml


### PR DESCRIPTION
Using .editorconfig to specify encodings.