### PR TITLE
Ignore IntelliJ compiler file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,6 @@ hs_err_pid*
 
 ### IntelliJ with EditorConfig ###
 .idea/encodings.xml
+
+### IntelliJ with Maven ###
+.idea/compiler.xml

--- a/src/main/resources/archetype-resources/.gitignore
+++ b/src/main/resources/archetype-resources/.gitignore
@@ -273,3 +273,6 @@ hs_err_pid*
 
 ### IntelliJ with EditorConfig ###
 .idea/encodings.xml
+
+### IntelliJ with Maven ###
+.idea/compiler.xml


### PR DESCRIPTION
Using Maven pom.xml to specify compiler settings.