### PR TITLE
Added IntelliJ config file

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="" />
+</component>


### PR DESCRIPTION
While the copyright settings aren't being used at the moment it's safer to add the file now rather than add it to the .gitignore file and cause issues with versioning it later.