### PR TITLE
Removed linkXRef from Checkstyle config

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -166,7 +166,6 @@
               <encoding>UTF-8</encoding>
               <consoleOutput>true</consoleOutput>
               <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
While it's in the usage example for the plugin it isn't a valid parameter for the plugin.