### PR TITLE
Increased project minimum Maven version to 3.3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <description>Maven Archetype for building simple Java Applications</description>
 
   <prerequisites>
-    <maven>3.2.5</maven>
+    <maven>3.3.9</maven>
   </prerequisites>
 
   <properties>
@@ -136,7 +136,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.2.5,3.4)</version>
+                  <version>[3.3.9,3.4)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.8,1.9)</version>


### PR DESCRIPTION
Increased minimum Maven version to 3.3.9 for the archetype project (rather than the generated archetype code).