### PR TITLE
Omit encoding on unfiltered file sets

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -14,7 +14,7 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
-    <fileSet encoding="UTF-8">
+    <fileSet>
       <directory>src/main/resources</directory>
       <includes>
         <include>.gitignore</include>
@@ -26,13 +26,13 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
-    <fileSet encoding="UTF-8">
+    <fileSet>
       <directory>src/test/resources</directory>
       <includes>
         <include>.gitignore</include>
       </includes>
     </fileSet>
-    <fileSet encoding="UTF-8">
+    <fileSet>
       <directory />
       <includes>
         <include>.editorconfig</include>
@@ -46,7 +46,7 @@
         <include>docker-compose.yml</include>
       </includes>
     </fileSet>
-    <fileSet encoding="UTF-8">
+    <fileSet>
       <directory>.idea</directory>
       <includes>
         <include>misc.xml</include>


### PR DESCRIPTION
The encoding is only used for filtering; including the attribute on other filesets is noisy and misleading.