### PR TITLE
Support Maven Wrapper on generated projects

### DIFF
--- a/src/main/resources/archetype-resources/.gitattributes
+++ b/src/main/resources/archetype-resources/.gitattributes
@@ -30,3 +30,4 @@
 *.jpg binary
 *.jpeg binary
 *.gif binary
+*.jar binary

--- a/src/main/resources/archetype-resources/.gitignore
+++ b/src/main/resources/archetype-resources/.gitignore
@@ -270,3 +270,8 @@ buildNumber.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### Project Specific ###
+
+# Allow Maven Wrapper JAR to be committed
+!/.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
While it can't be included by default (Maven archetype doesn't preserve the execute bit), the .gitattributes and .gitignore can be preconfigured to support Maven Wrapper being added after generate is run.