### PR TITLE
Build with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-language: java
-jdk:
-  - oraclejdk8
-
 # Require the standard build environment
 sudo: required
 
@@ -16,11 +12,7 @@ cache:
   directories:
     - ~/.m2
 
-script: ./mvnw install site --batch-mode --show-version
-
-after_success:
-  - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" == "" && ./mvnw site-deploy --settings .travis/settings.xml --batch-mode --show-version
-  - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && ./mvnw deploy --settings .travis/settings.xml -P publish-artifacts --batch-mode --show-version && ./mvnw site-deploy --settings .travis/settings.xml -P release --batch-mode --show-version
+script: .travis/build.sh
 
 env:
   global:

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+mvn() {
+    docker run --rm -it \
+        -v ~/.m2:/root/.m2 \
+        -v "$PWD":/usr/src/maven-build \
+        -w /usr/src/maven-build \
+        -e "BINTRAY_USER=$BINTRAY_USER" \
+        -e "BINTRAY_API_KEY=$BINTRAY_API_KEY" \
+        -e "GITHUB_OAUTH2TOKEN=$GITHUB_OAUTH2TOKEN" \
+        maven:3.3.9-jdk-8-alpine mvn $@
+}
+
+mvn install site --batch-mode --show-version
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    if [ "$TRAVIS_TAG" == "" ]; then
+        mvn site-deploy --settings .travis/settings.xml --batch-mode
+    else
+        mvn deploy --settings .travis/settings.xml -P publish-artifacts --batch-mode \
+            && mvn site-deploy --settings .travis/settings.xml -P release --batch-mode
+    fi
+fi


### PR DESCRIPTION
Travis CI lacks direct support for choosing the Maven version so building using Docker.