### PR TITLE
Added VersionEye check on generated project

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -60,11 +60,15 @@ mvn() {
 
 mvn install site --batch-mode --show-version
 
+GENERATED_DIR=target/test-classes/projects/basic/project/java-application-maven-archetype-generated
+PROJECT_ID=57df1519c2cd3f00100b7741
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_BRANCH" == "master" ]; then
         mvn versioneye:update
+        (cd $GENERATED_DIR && mvn versioneye:update -DprojectId=$PROJECT_ID)
     else
         mvn versioneye:securityAndLicenseCheck
+        (cd $GENERATED_DIR && mvn versioneye:securityAndLicenseCheck -DprojectId=$PROJECT_ID)
     fi
 
     if [ "$TRAVIS_TAG" == "" ]; then

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -70,6 +70,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.versioneye</groupId>
+          <artifactId>versioneye-maven-plugin</artifactId>
+          <version>3.10.2</version>
+        </plugin>
+        <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
           <version>0.16.2</version>

--- a/src/test/resources/projects/basic/archetype.properties
+++ b/src/test/resources/projects/basic/archetype.properties
@@ -1,6 +1,6 @@
 #Mon Jul 11 10:15:40 BST 2016
 package=it.pkg
 version=0.1-SNAPSHOT
-groupId=archetype.it
-artifactId=basic
+groupId=com.github.gantsign.java-application-maven-archetype
+artifactId=java-application-maven-archetype-generated
 dockerRepository=archetype/test


### PR DESCRIPTION
Build will now fail if a plugin/dependency is out of date or its license is not permitted.