### PR TITLE
Show compiler warnings

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -127,6 +127,7 @@
             <compilerId>javac-with-errorprone</compilerId>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <showDeprecation>true</showDeprecation>
+            <showWarnings>true</showWarnings>
           </configuration>
           <dependencies>
             <!-- override plexus-compiler-javac-errorprone's dependency on


### PR DESCRIPTION
Enable warnings built into the compiler and provided by Google Error Prone.