### PR TITLE
Fixed continuation indent in IntelliJ IDEA

### DIFF
--- a/src/main/resources/archetype-resources/.editorconfig
+++ b/src/main/resources/archetype-resources/.editorconfig
@@ -8,11 +8,13 @@ root = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+continuation_indent_size = 8
 trim_trailing_whitespace = true
 
 # Files with a smaller indent
 [*.{java,xml,yml}]
 indent_size = 2
+continuation_indent_size = 4
 
 # Java file encoding
 [*.java]


### PR DESCRIPTION
Was defaulting to the same as the normal intent.