### PR TITLE
Enforce no duplicate classes

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -314,6 +314,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.4.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.0-beta-5</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -356,6 +363,9 @@
                 <requireNoRepositories>
                   <message>Best Practice is to never define repositories in pom.xml (use a repository manager instead)</message>
                 </requireNoRepositories>
+                <banDuplicateClasses>
+                  <findAllDuplicates>true</findAllDuplicates>
+                </banDuplicateClasses>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Used Maven Enforcer to ban duplicate classes.

Duplicate classes lead to:
* Unpredictable behaviour at compile and runtime
* Failure when using Java 9 auto module
* Increased space usage
* Reduced build performance