### PR TITLE
Updated Google Error Prone compiler plugin

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -140,7 +140,7 @@
             <dependency>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.0.12</version>
+              <version>2.0.13</version>
             </dependency>
             <dependency>
               <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Updated Google Error Prone from 2.0.12 to 2.0.13.