### PR TITLE
Fixed unnecessary updates of Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ dist: trusty
 services:
   - docker
 
+before_cache:
+  - rm --force --recursive --verbose $HOME/.m2/repository/com/github/gantsign
+
 cache:
   directories:
-    - ~/.m2
+    - $HOME/.m2
 
 script: .travis/build.sh
 


### PR DESCRIPTION
It was updating every time because the build artefacts were included in the cache.