### PR TITLE
Removed prerequisites tags from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,6 @@
   <name>Java Application Maven Archetype</name>
   <description>Maven Archetype for building simple Java Applications</description>
 
-  <prerequisites>
-    <maven>3.3.9</maven>
-  </prerequisites>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <site.path>snapshot</site.path>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -6,10 +6,6 @@
   <artifactId>${artifactId}</artifactId>
   <version>${version}</version>
 
-  <prerequisites>
-    <maven>3.2.5</maven>
-  </prerequisites>
-
   <properties>
     <dependencies.slf4j.version>1.7.25</dependencies.slf4j.version>
     <docker.repository>${dockerRepository}</docker.repository>


### PR DESCRIPTION
Prerequisite tags are meant for plugin use only and Maven enforcer does the same check anyway.