### PR TITLE
Updated Plexus Compiler Javac Error Prone to 2.8.4

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-compiler-javac-errorprone</artifactId>
-              <version>2.8.1</version>
+              <version>2.8.4</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Keeping up with the latest changes.